### PR TITLE
Automatically check branch coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ npm-debug.*
 *.orig.*
 web-build/
 .env
+coverage/
 
 # macOS
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web",
     "build": "expo export:web",
     "lint": "eslint ./src/**/*.{js,jsx} App.jsx --no-error-on-unmatched-pattern",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "jest": {
     "preset": "jest-expo",
@@ -19,7 +19,12 @@
     },
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-router-native)"
-    ]
+    ],
+    "coverageThreshold": {
+        "global": {
+            "branches": 70
+        }
+    }
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",


### PR DESCRIPTION
Check that branch coverage is at least 70% (as stated in DoD) whenever running `npm run test`. This also affects CI pipeline, so the branch coverage is automatically ensured to be high enough before merging branches to main.