### PR TITLE
only one workflow will run at a time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,9 @@ on:
 jobs:
     simple_deployment_pipeline:
       runs-on: ubuntu-20.04
+      concurrency:
+        group: e2e-tests
+        cancel-in-progress: false
       env:
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
       steps:


### PR DESCRIPTION
Made it so that only one workflow with e2e tests will run at a time. This ensures that e2e tests will not fail because of multiple connections from multiple workflows. With this setup, if another workflow starts while there is a workflow already running, the new workflow will get a "pending" status. There can only be one workflow running and one workflow pending. Older pending workflow will be canceled if a new workflow is being run.

For more information:
https://docs.github.com/en/actions/using-jobs/using-concurrency 