### PR TITLE
Rahti domain fix

### DIFF
--- a/openshift/prod-deployment.yaml
+++ b/openshift/prod-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: BACKEND_POSTGRES_URL
               value: postgres://postgres:$(POSTGRES_PASSWORD)@ruokasovellus-db-prod-service:5432/ruokasovellus
             - name: WEBPAGE_URL
-              value: http://ruokasovellus.2.rahtiapp.fi
+              value: https://www.ruokalaskuri.fi
           envFrom:
             - secretRef:
                 # pulls POSTGRES_PASSWORD, SECRET_KEY and DATABASE_ENCRYPTION_KEY env vars


### PR DESCRIPTION
Before this fix, privacy policy link and all QR codes exported in production used the ugly Rahti subdomain, whereas after this fix they use our nice custom domain.