### PR TITLE
Playwright timeouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,10 @@ require('dotenv').config();
  */
 export default defineConfig({
   testDir: './e2e-tests',
+  timeout: 60000,
+  expect: {
+    timeout: 10000,
+  },
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
Increase the default timeout of end-to-end tests to 60 seconds and the default timeout of each `expect` to 10 seconds.